### PR TITLE
Upgrading to Hibernate 6

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -30,13 +30,6 @@
       <artifactId>quarkus-jdbc-sqlite</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-<!--    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-community-dialects</artifactId>
-      <version>6.1.0.Final</version>
-    </dependency>-->
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-internal</artifactId>

--- a/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/SqliteHibernateProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/SqliteHibernateProcessor.java
@@ -1,13 +1,11 @@
 package io.quarkiverse.jdbc.sqlite.deployment;
 
-import org.sqlite.hibernate.dialect.SQLiteDialect;
+import org.hibernate.community.dialect.SQLiteDialect;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.hibernate.orm.deployment.spi.DatabaseKindDialectBuildItem;
 
-//https://github.com/gwenn/sqlite-dialect/
-@SuppressWarnings("unused")
 public class SqliteHibernateProcessor {
 
     @BuildStep

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,8 @@
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.0.0.Alpha4</quarkus.version>
+    <quarkus.version>3.0.0.Alpha6</quarkus.version>
     <sqlite-jdbc.version>3.41.0.0</sqlite-jdbc.version>
-    <sqlite-dialect.version>0.1.2</sqlite-dialect.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -26,15 +26,8 @@
       <version>${sqlite-jdbc.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.gwenn</groupId>
-      <artifactId>sqlite-dialect</artifactId>
-      <version>${sqlite-dialect.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate</groupId>
-          <artifactId>hibernate-core</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-community-dialects</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Hey @alexeysharandin, this upgrades this extension to the latest Quarkus 3 Alpha release and in the course of doing so, also to Hibernate 6 (using the SQLite dialect from its community dialects project). Tests pass both in JVM and native mode.