### PR TITLE
Bump org.xerial:sqlite-jdbc from 3.43.2.1 to 3.44.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "3.0.6"
+  current-version: "3.0.7"
   next-version: "999-SNAPSHOT"
 


### PR DESCRIPTION
Bump quarkus.version from 3.5.0 to 3.6.0  dependencies

Release 3.0.7