### PR TITLE
Bump quarkus.version from 3.9.3 to 3.9.4 and Bump org.xerial:sqlite-jdbc from 3.45.2.0 to 3.45.3.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "3.0.7"
+  current-version: "3.0.8"
   next-version: "999-SNAPSHOT"
 


### PR DESCRIPTION
Bump quarkus.version from 3.9.3 to 3.9.4 and Bump org.xerial:sqlite-jdbc from 3.45.2.0 to 3.45.3.0