### PR TITLE
Add JdbcDriver with DB-kind to use SqliteAgroalConnectionConfigurer

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/JDBCSqliteProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/JDBCSqliteProcessor.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.jdbc.sqlite.deployment;
 
+import static io.quarkiverse.jdbc.sqlite.runtime.SQLiteConstants.DB_KIND;
+
 import org.sqlite.JDBC;
 import org.sqlite.SQLiteDataSource;
 
@@ -27,7 +29,6 @@ class JDBCSqliteProcessor {
 
     static final String DRIVER_NAME = JDBC.class.getName();
     private static final String DATA_SOURCE_NAME = SQLiteDataSource.class.getName();
-    private static final String DB_KIND = "sqlite";
 
     @BuildStep
     FeatureBuildItem feature() {

--- a/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/JDBCSqliteProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/JDBCSqliteProcessor.java
@@ -19,7 +19,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.SslNativeConfigBuildItem;
 
 /**
- * Deploy extention to Quarkus framework
+ * Deploy extension to Quarkus framework
  *
  */
 @SuppressWarnings("unused")

--- a/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/SqliteHibernateProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jdbc/sqlite/deployment/SqliteHibernateProcessor.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.jdbc.sqlite.deployment;
 
+import io.quarkiverse.jdbc.sqlite.runtime.SQLiteConstants;
 import org.hibernate.community.dialect.SQLiteDialect;
 
 import io.quarkus.deployment.annotations.BuildProducer;
@@ -11,6 +12,6 @@ public class SqliteHibernateProcessor {
     @BuildStep
     void processHibernate(
             BuildProducer<DatabaseKindDialectBuildItem> producer) {
-        producer.produce(new DatabaseKindDialectBuildItem("sqlite", SQLiteDialect.class.getName()));
+        producer.produce(new DatabaseKindDialectBuildItem(SQLiteConstants.DB_KIND, SQLiteDialect.class.getName()));
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jdbc/sqlite/runtime/SQLiteConstants.java
+++ b/runtime/src/main/java/io/quarkiverse/jdbc/sqlite/runtime/SQLiteConstants.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.jdbc.sqlite.runtime;
+
+/**
+ * Constants for SQLite.
+ */
+public class SQLiteConstants {
+
+    private SQLiteConstants() {
+        // cannot be instantiated - constant class
+    }
+
+    /**
+     * DB-kind.
+     */
+    public static final String DB_KIND = "sqlite";
+
+}

--- a/runtime/src/main/java/io/quarkiverse/jdbc/sqlite/runtime/SqliteAgroalConnectionConfigurer.java
+++ b/runtime/src/main/java/io/quarkiverse/jdbc/sqlite/runtime/SqliteAgroalConnectionConfigurer.java
@@ -5,7 +5,7 @@ import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
 import io.quarkus.agroal.runtime.JdbcDriver;
 
 /**
- * Emply Agoral configurer
+ * Empty Agroal configurer
  *
  */
 @JdbcDriver(SQLiteConstants.DB_KIND)
@@ -13,12 +13,12 @@ public class SqliteAgroalConnectionConfigurer implements AgroalConnectionConfigu
 
     @Override
     public void disableSslSupport(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
-        // do not log anything for H2
+        // do not log anything for SQLite
     }
 
     @Override
     public void setExceptionSorter(String databaseKind, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
-        // Do not log a warning: we don't have an exception sorter for H2,
+        // Do not log a warning: we don't have an exception sorter for SQLite,
         // but there is nothing the user can do about it.
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/jdbc/sqlite/runtime/SqliteAgroalConnectionConfigurer.java
+++ b/runtime/src/main/java/io/quarkiverse/jdbc/sqlite/runtime/SqliteAgroalConnectionConfigurer.java
@@ -2,11 +2,13 @@ package io.quarkiverse.jdbc.sqlite.runtime;
 
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.quarkus.agroal.runtime.AgroalConnectionConfigurer;
+import io.quarkus.agroal.runtime.JdbcDriver;
 
 /**
  * Emply Agoral configurer
  *
  */
+@JdbcDriver(SQLiteConstants.DB_KIND)
 public class SqliteAgroalConnectionConfigurer implements AgroalConnectionConfigurer {
 
     @Override


### PR DESCRIPTION
- Adding the `JdbcDriver` missing annotation ensures that the agroal configurer provided by the extension is used (fixes #153).
- Also fixes typos on the modified classes